### PR TITLE
Allow non-linear traversal through tests

### DIFF
--- a/client/src/components/Question.jsx
+++ b/client/src/components/Question.jsx
@@ -5,7 +5,7 @@ const Question = (props) => {
     const labels = ["a", "b", "c", "d", "e"];
     const answerChoices = [];
     // The images cannot be retrieved through their filename (array, not object)
-    for (var i = 0; i < answers.length; i++) {
+    for (let i = 0; i < answers.length; i++) {
       answerChoices.push(
         <div className="answer__choice" key={labels[i]}>
           <label htmlFor={labels[i]}>

--- a/client/src/components/QuestionNavigation.jsx
+++ b/client/src/components/QuestionNavigation.jsx
@@ -1,6 +1,5 @@
 const QuestionNavigation = (props) => {
-  const { numberOfQuestions, onClick } = props;
-
+  const { numberOfQuestions, onClick, answers, currentQuestion } = props;
 
   const renderQuestionNavigation = () => {
     let questionSelectButtons = [];
@@ -11,8 +10,12 @@ const QuestionNavigation = (props) => {
           onClick={() => onClick(i+1)}
           title="Go to question"
           key={i + 1}
+          style={{
+            background: (answers[i].aId || answers[i].value) ? "var(--accent-color)" : null,
+            outline: currentQuestion == i + 1 ? "1.5px solid var(--accent-color)" : null,
+          }}
         >
-          <p>{i + 1}</p>
+          {i + 1}
         </button>
       )
     }

--- a/client/src/components/QuestionNavigation.jsx
+++ b/client/src/components/QuestionNavigation.jsx
@@ -1,0 +1,29 @@
+const QuestionNavigation = (props) => {
+  const { numberOfQuestions, onClick } = props;
+
+
+  const renderQuestionNavigation = () => {
+    let questionSelectButtons = [];
+    for (let i = 0; i < numberOfQuestions; i++) {
+      questionSelectButtons.push(
+        <button 
+          className="question-select__button"
+          onClick={() => onClick(i+1)}
+          title="Go to question"
+          key={i + 1}
+        >
+          <p>{i + 1}</p>
+        </button>
+      )
+    }
+    return questionSelectButtons;
+  }
+
+  return (
+    <div className="test__question-select">
+      {renderQuestionNavigation()}
+    </div>
+  )
+}
+
+export default QuestionNavigation;

--- a/client/src/containers/Test.jsx
+++ b/client/src/containers/Test.jsx
@@ -60,9 +60,6 @@ const Test = (props) => {
   }, []);
 
   const nextQuestion = () => {
-    // if (userAnswers[currentQuestion - 1].aId === null && timeLeft > 0) {
-    //   return; // Prevent user from proceeding if no answer given
-    // }
     console.log(userAnswers); // for debugging
     setSelectedAnswer(userAnswers[currentQuestion].aId);
     if (currentQuestion < questionBank.length) {
@@ -70,25 +67,9 @@ const Test = (props) => {
       if (!allowBackTraversal) {
         setTimeLeft(questionTimeBank[currentQuestion]);
       }
-      return true;
+      return;
     } else {
-      if (userData.name) {
-        // Create answer in DB if user logged in
-        let testData = {
-          tId: testId,
-          sId: userData.name,
-          answers: userAnswers,
-        };
-
-        axios
-          .post("http://localhost:3001/api/answer", testData)
-          .then(
-            window.location.replace(
-              `http://localhost:3000/results/${testId}/${userData.name}`
-            )
-          );
-      }
-      return false;
+      finishTest();  // No more questions.
     }
   };
 
@@ -105,7 +86,20 @@ const Test = (props) => {
   }
 
   const finishTest = () => {
-
+    if (userData.name) {
+      // Create answer in DB if user logged in
+      let testData = {
+        tId: testId,
+        sId: userData.name,
+        answers: userAnswers,
+      };
+      axios.post("http://localhost:3001/api/answer", testData).then(
+        window.location.replace(`http://localhost:3000/results/${testId}/${userData.name}`)
+      );
+    } else {
+      alert("Test Finished. You are not logged in, so your results wont be saved.")
+      window.location.href(`http://localhost:3000/`);
+    }
   }
 
   const submitAnswer = (event) => {
@@ -132,8 +126,10 @@ const Test = (props) => {
 
   const timeCountDown = () => {
     if (timeLeft <= 0) {
-      if (!nextQuestion()) {
-        clearInterval(Ref.current);
+      if (allowBackTraversal) {
+        finishTest();
+      } else {
+        nextQuestion();
       }
     } else {
       setTimeLeft(timeLeft - 1);

--- a/client/src/containers/Test.jsx
+++ b/client/src/containers/Test.jsx
@@ -4,6 +4,7 @@ import { FaCaretLeft, FaCaretRight } from "react-icons/fa";
 import TimerDisplay from "../components/TimerDisplay";
 import Timer from "../components/Timer";
 import Question from "../components/Question";
+import QuestionNavigation from "../components/QuestionNavigation";
 import MatchingGame from "../components/MatchingGame/MatchingGame";
 import PatternGame from "../components/PatternGame/PatternGame";
 import axios from "axios";
@@ -61,8 +62,8 @@ const Test = (props) => {
 
   const nextQuestion = () => {
     console.log(userAnswers); // for debugging
-    setSelectedAnswer(userAnswers[currentQuestion].aId);
     if (currentQuestion < questionBank.length) {
+      setSelectedAnswer(userAnswers[currentQuestion].aId);
       setCurrentQuestion(currentQuestion + 1);
       if (!allowBackTraversal) {
         setTimeLeft(questionTimeBank[currentQuestion]);
@@ -98,7 +99,7 @@ const Test = (props) => {
       );
     } else {
       alert("Test Finished. You are not logged in, so your results wont be saved.")
-      window.location.href(`http://localhost:3000/`);
+      // window.location.href(`http://localhost:3000/`);
     }
   }
 
@@ -126,6 +127,7 @@ const Test = (props) => {
 
   const timeCountDown = () => {
     if (timeLeft <= 0) {
+      clearInterval(Ref.current);
       if (allowBackTraversal) {
         finishTest();
       } else {
@@ -146,16 +148,19 @@ const Test = (props) => {
     Ref.current = id;
   };
 
+
   if (error) {
     return <div>Error: {error.message}</div>;
   } else if (!isLoaded) {
     return <div>Loading Test...</div>;
   } else {  
     // Test loaded successfully
-    
     let testQuestion;
+    startTimer();
     if (getCurrentQuestion().category === "Spatial Memory") {
-      clearInterval(Ref.current)  // Stop timer
+      if (!allowBackTraversal) {
+        clearInterval(Ref.current)  // Stop timer if the test is linear.
+      }
       if (getCurrentQuestion().title === "MatchingGame") {
         testQuestion = <MatchingGame
             timeAllowed={questionTimeBank[currentQuestion - 1]}
@@ -179,8 +184,8 @@ const Test = (props) => {
           submit={submitAnswer}
           selected={selectedAnswer}
         />
-      startTimer();
     }
+    
     
     return (
       <div className="test">
@@ -188,7 +193,7 @@ const Test = (props) => {
           <TimerDisplay seconds={timeLeft} />
         }
         
-        {currentQuestion === 1 && allowBackTraversal ? null : 
+        {allowBackTraversal && currentQuestion != 1 ? 
           <button
             className="test__previous"
             onClick={() => previousQuestion()}
@@ -196,8 +201,8 @@ const Test = (props) => {
           >
             <FaCaretLeft size={60} />
           </button>
+          : null
         }
-
 
         {testQuestion}
 
@@ -214,6 +219,13 @@ const Test = (props) => {
             <FaCaretRight size={60} />
           </button>
         )}
+
+        {allowBackTraversal ? 
+        <QuestionNavigation 
+          numberOfQuestions={questionBank.length}
+          onClick={setCurrentQuestion}
+        /> 
+        : null}
 
         <Timer
           questionTime={ allowBackTraversal ? 

--- a/client/src/containers/Test.jsx
+++ b/client/src/containers/Test.jsx
@@ -25,7 +25,7 @@ const Test = (props) => {
   const url = "http://localhost:3001/api/test/getquestions";
   // const testId = "6319abdf2d143b5bfa3de54a"; // Use values from props later.
   // const testId = "6322b155323d447d6c5f7eb6";  // Memory games included
-  const testId = "632efea0a6069a23596d3347"; // Non-linear
+  const testId = "633127cf6005f2c17949b366"; // Non-linear
   const data = {
     tId: testId,
     shuffleQuestions: false,
@@ -186,10 +186,10 @@ const Test = (props) => {
         />
     }
     
-    
     return (
       <div className="test">
-        { getCurrentQuestion().category === "Spatial Memory" ? null : 
+        { getCurrentQuestion().category === "Spatial Memory" && !allowBackTraversal
+         ? null : 
           <TimerDisplay seconds={timeLeft} />
         }
         
@@ -224,15 +224,16 @@ const Test = (props) => {
         <QuestionNavigation 
           numberOfQuestions={questionBank.length}
           onClick={setCurrentQuestion}
-        /> 
-        : null}
-
+          answers={userAnswers}
+          currentQuestion={currentQuestion}
+        /> :
         <Timer
-          questionTime={ allowBackTraversal ? 
-            questionTimeBank.reduce((partialSum, a) => partialSum + a, 0) :
-            questionTimeBank[currentQuestion - 1]}
-          timeLeft={timeLeft}
-        />
+        questionTime={ allowBackTraversal ? 
+          questionTimeBank.reduce((partialSum, a) => partialSum + a, 0) :
+          questionTimeBank[currentQuestion - 1]}
+        timeLeft={timeLeft}
+        />}
+
       </div>
     );
   }

--- a/client/src/containers/TestResult.jsx
+++ b/client/src/containers/TestResult.jsx
@@ -6,23 +6,21 @@ import axios from "axios";
 
 const TestResult = () => {
   let { tId, sId } = useParams();
-  const [userAnswers, setUserAnswers] = useState(null);
-  const [grade, setGrade] = useState(null);
+  const [data, setData] = useState(null);
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
 
   const url = 'http://localhost:3001/api/answer/getStudentAnswer';
-  const data = {
+  const body = {
     tId: tId,
     sId: sId
   };
 
   useEffect(() => {
-    axios.post(url, data)
+    axios.post(url, body)
     .then((res) => {
       console.log(res);
-      setUserAnswers(res.data.answers);
-      setGrade(res.data.grade);
+      setData(res.data);
       setIsLoaded(true);
     },
     (error) => {
@@ -32,10 +30,15 @@ const TestResult = () => {
   }, [])
 
   const renderAnswers = () => {
-    const answers = userAnswers.map((ans) => {
+    const answers = data.testQuestions.map((ans) => {
       return (
         <li key={ans.qId}>
-          {ans.correct ? 'Correct' : 'Wrong'} Value: {ans.value}
+          <img src={ans.image} alt='No Image'/>
+          <p>Category: {ans.category}</p>
+          <p>Description: {ans.description}</p>
+          <p>Grade: {ans.grade}</p>
+          <p>{ans.correct ? 'Correct' : 'Wrong'}</p>
+          <p>Value: {ans.value}</p>
         </li>
       )
     })
@@ -51,9 +54,9 @@ const TestResult = () => {
       <div className='results'>
         <div>
           <h1>Test Result Page</h1>
-          <h1>Test {tId}</h1>
-          <h1>Taken by {sId}</h1>
-          <h1>Grade: {grade}</h1>
+          <h1>Test Name: {data.testTitle}</h1>
+          <h1>Student Name: {data.sId}</h1>
+          <h1>Grade: {data.studentGrade} / {data.testMaxGrade}</h1>
           <ol type="1">
             {renderAnswers()}
           </ol>

--- a/client/src/styles/Test.css
+++ b/client/src/styles/Test.css
@@ -96,6 +96,20 @@
     animation: fadeIn 1s;
 }
 
+.test__previous {
+    display: flex;
+    border: none;
+    position: absolute;
+    padding: 0;
+    left: 1rem;
+    background-color: transparent;
+    color: var(--accent-color);
+    fill: var(--accent-color);
+    cursor: pointer;
+    transition: color .25s;
+    animation: fadeIn 1s;
+}
+
 .test__next:hover {
     color: #1b7be9;
 }

--- a/client/src/styles/Test.css
+++ b/client/src/styles/Test.css
@@ -138,6 +138,24 @@
     cursor: default;
 }
 
+.test__question-select {
+    position: absolute;
+    bottom: 2rem;
+    width: 100%;
+    
+}
+
+.question-select__button {
+    padding: 0.5rem;
+    margin: 1rem;
+    font-size: 1.5rem;
+    border-radius: 8px;
+    /* outline: 1.5px solid; */
+}
+.question-select__button:hover {
+    outline: 1.5px solid var(--accent-color);
+}
+
 @keyframes fadeIn {
     0% {opacity: 0;}
     100% {opacity: 1;}

--- a/server/controllers/answer-controller.mjs
+++ b/server/controllers/answer-controller.mjs
@@ -124,15 +124,19 @@ const getStudentAnswerBytIdsId = async (req, res, next) => {
   }
 
   const test = await Test.findById(req.body.tId).exec();
-  var testMaxGrade = 0;
-  var testQuestions = [];
+  let testMaxGrade = 0;
+  let studentGrade = 0;
+  let testQuestions = [];
   test.questions.forEach(q => { 
     testMaxGrade += q.grade;
     let question = questions.find(obj => obj._id == q.qId);  // Full question object
     let answer = studentAnswer.answers.find(ans => ans.qId == q.qId);  // Get student answer for question
+    if (answer.correct) {
+      studentGrade += q.grade;
+    }
     testQuestions.push(
       {
-        id: q.qId,
+        qId: q.qId,
         grade: q.grade,
         image: question.image,
         category: question.category,
@@ -145,9 +149,11 @@ const getStudentAnswerBytIdsId = async (req, res, next) => {
 
   const result = {
     tId: studentAnswer.tId,
+    sId: studentAnswer.sId,
     testTitle: test.title,
     testCreator: test.creator,
     testMaxGrade: testMaxGrade,
+    studentGrade: studentGrade,
     testQuestions: testQuestions,
   }
 

--- a/server/controllers/test-controller.mjs
+++ b/server/controllers/test-controller.mjs
@@ -111,7 +111,13 @@ const getQuestionsBytId = async (req, res, next) => {
   const timeOut = questionsOut.map(
     (qo) => test.questions.find((q) => q.qId === qo.id).time
   );
-  const combined = { questions: questionsOut, times: timeOut };
+
+  const combined = { questions: questionsOut,
+    times: timeOut, 
+    allowBackTraversal: test.allowBackTraversal,
+    // totalTime: test.totalTime,
+    totalTime: timeOut.reduce((partialSum, a) => partialSum + a, 0)
+  };
   res.json(combined);
 };
 

--- a/server/controllers/test-controller.mjs
+++ b/server/controllers/test-controller.mjs
@@ -115,8 +115,8 @@ const getQuestionsBytId = async (req, res, next) => {
   const combined = { questions: questionsOut,
     times: timeOut, 
     allowBackTraversal: test.allowBackTraversal,
-    // totalTime: test.totalTime,
-    totalTime: timeOut.reduce((partialSum, a) => partialSum + a, 0)
+    totalTime: test.totalTime,
+    // totalTime: timeOut.reduce((partialSum, a) => partialSum + a, 0)
   };
   res.json(combined);
 };

--- a/server/controllers/test-controller.mjs
+++ b/server/controllers/test-controller.mjs
@@ -115,8 +115,8 @@ const getQuestionsBytId = async (req, res, next) => {
   const combined = { questions: questionsOut,
     times: timeOut, 
     allowBackTraversal: test.allowBackTraversal,
-    totalTime: test.totalTime,
-    // totalTime: timeOut.reduce((partialSum, a) => partialSum + a, 0)
+    // totalTime: test.totalTime,
+    totalTime: timeOut.reduce((partialSum, a) => partialSum + a, 0)
   };
   res.json(combined);
 };

--- a/server/controllers/test-controller.mjs
+++ b/server/controllers/test-controller.mjs
@@ -40,6 +40,7 @@ const createTest = async (req, res, next) => {
     studentAnswers: [],
     published: req.body.published,
     allowBackTraversal: req.body.allowBackTraversal,
+    totalTime: req.body.totalTime,
     code: await createCode(),
   });
 

--- a/server/controllers/test-controller.mjs
+++ b/server/controllers/test-controller.mjs
@@ -39,6 +39,7 @@ const createTest = async (req, res, next) => {
     })),
     studentAnswers: [],
     published: req.body.published,
+    allowBackTraversal: req.body.allowBackTraversal,
     code: await createCode(),
   });
 

--- a/server/models/test-in.js
+++ b/server/models/test-in.js
@@ -4,6 +4,7 @@ class TestIn {
     this.creator = test.creator;
     this.questions = test.questions;
     this.published = test.published;
+    this.allowBackTraversal = test.allowBackTraversal;
   }
 }
 

--- a/server/models/test-in.js
+++ b/server/models/test-in.js
@@ -5,6 +5,7 @@ class TestIn {
     this.questions = test.questions;
     this.published = test.published;
     this.allowBackTraversal = test.allowBackTraversal;
+    this.totalTime = test.totalTime;
   }
 }
 

--- a/server/models/test-out.js
+++ b/server/models/test-out.js
@@ -6,6 +6,7 @@ class TestOut {
     this.published = test.published;
     this.code = test.code;
     this.allowBackTraversal = test.allowBackTraversal;
+    this.totalTime = test.totalTime;
   }
 }
 

--- a/server/models/test-out.js
+++ b/server/models/test-out.js
@@ -5,6 +5,7 @@ class TestOut {
     this.questions = test.questions;
     this.published = test.published;
     this.code = test.code;
+    this.allowBackTraversal = test.allowBackTraversal;
   }
 }
 

--- a/server/models/test.js
+++ b/server/models/test.js
@@ -15,6 +15,7 @@ const testSchema = new mongoose.Schema({
   studentAnswers: [StudentAnswer.schema],
   published: { type: Boolean, required: true },
   code: { type: String, required: true },
+  allowBackTraversal: { type: Boolean, required: false },
 });
 
 //Check if question already a model before exporting

--- a/server/models/test.js
+++ b/server/models/test.js
@@ -16,6 +16,7 @@ const testSchema = new mongoose.Schema({
   published: { type: Boolean, required: true },
   code: { type: String, required: true },
   allowBackTraversal: { type: Boolean, required: false },
+  totalTime: { type: Number, required: false }
 });
 
 //Check if question already a model before exporting


### PR DESCRIPTION
## Issue

Client wanted an option for our tests to be have a standard total time, with users being able to switch freely between questions in any order.

## Solution

Added a nullable, boolean `allowBackTraversal` field to the `Test` model object, which will differentiate between a non-linear and linear test. A `totalTime` field is also added, although it is not used, as the total time is currently being calculated by getting the sum of all question times.
![image](https://user-images.githubusercontent.com/29995754/192203596-a1edf5a6-70cc-4ce4-9f7e-6f5cce31ba71.png)

If the test is non-linear, then it conditionally renders certain components, such as the `previousQuestion` and `QuestionNavigation` buttons. The time slider is not shown for non-linear tests.
![image](https://user-images.githubusercontent.com/29995754/192203408-e03cb1e9-7582-4e7f-8289-67194e5265a4.png)
Test behaviour also reflects a non-linear test; the timer is not paused by memory game questions, and the test is submitted when the timer finishes counting.

The proof-of-concept results page was also rewritten to show off the improved studentAnswer endpoint.

## Potential improvements
- Separating the single `Test` component into Linear and Non-linear test components, as currently there is a lot of conditional checks. (I wasn't sure how the app was going to check the test linearity, so I wrote the checks within the component)
- Prevent the user from redoing a memory game if they already did it in a non-linear test.
- Checks to prevent the user from finishing the test without answering all questions

## Reviewed By

Note who reviewed your pull request.
