### PR TITLE
Disable Enter Key during test

### DIFF
--- a/client/src/containers/Test.jsx
+++ b/client/src/containers/Test.jsx
@@ -27,12 +27,10 @@ const Test = (props) => {
   
   // Disable enter key entirely, prevents next button from disappearing.
   window.addEventListener('keydown', function(e) { 
-    if(e.keyIdentifier=='U+000A'||e.keyIdentifier=='Enter') {
-      if (e.target.nodeName=='INPUT'&&e.target.type=='text') {
-        e.preventDefault();return false;
-      }
+    if (e.key === "Enter") {
+        e.preventDefault();
     }
-  }, true);
+  });
 
   // Load test data from backend API
   useEffect(() => {
@@ -212,7 +210,9 @@ const Test = (props) => {
               <p>Test Time: {
                 allowBackTraversal ? totalTime / 60 : 
                 // Sum of individual question time for linear test
-                questions.map(q => parseInt(q.totalTime.$numberDecimal)).reduce((a, b) => a + b, 0) / 60
+                Math.round(
+                  questions.map(q => parseInt(q.totalTime.$numberDecimal)).reduce((a, b) => a + b, 0) / 60
+                )
               } minutes
               </p>
               { allowBackTraversal ? null : <p>Each question has an individual time limit</p>}

--- a/client/src/containers/Test.jsx
+++ b/client/src/containers/Test.jsx
@@ -48,7 +48,7 @@ const Test = (props) => {
         
         let defaultAns = [];
         for (const q of res.data.questions) {
-          defaultAns.push({ qId: q.qId, questionType: q.questionType, aIds: [], textAnswer: null, value: null });
+          defaultAns.push({ qId: q.qId, questionType: q.questionType, aIds: [], textAnswer: "", value: null });
         }
         setUserAnswers(defaultAns);
         setIsLoaded(true);

--- a/client/src/containers/Test.jsx
+++ b/client/src/containers/Test.jsx
@@ -25,6 +25,15 @@ const Test = (props) => {
   const [testDetails, setTestDetails] = useState({})
   const testCode = sessionStorage.getItem("code");
   
+  // Disable enter key entirely, prevents next button from disappearing.
+  window.addEventListener('keydown', function(e) { 
+    if(e.keyIdentifier=='U+000A'||e.keyIdentifier=='Enter') {
+      if (e.target.nodeName=='INPUT'&&e.target.type=='text') {
+        e.preventDefault();return false;
+      }
+    }
+  }, true);
+
   // Load test data from backend API
   useEffect(() => {
     if (!userData.name) {


### PR DESCRIPTION
Prevent the Enter key from doing anything during the test, e.g resetting the form input value and hiding the next button.

Also rounded the total time during the test introduction page so we don't get values like 10.33333 minutes.