### PR TITLE
Admin redirects

### DIFF
--- a/client/src/components/Question.jsx
+++ b/client/src/components/Question.jsx
@@ -89,7 +89,7 @@ const Question = (props) => {
         corsi={question.corsi}
         description={question.description}
         gameDim={question.size} // width and height of grid
-        order={false} // pattern order/no-order
+        order={question.order} // pattern order/no-order
         maxHealth={question.lives}
         timerState={question.totalTime.$numberDecimal === 0 ? true : false} // set timer on/off
         timeAllowed={question.totalTime.$numberDecimal} // total time if timer on

--- a/client/src/containers/App.jsx
+++ b/client/src/containers/App.jsx
@@ -45,7 +45,7 @@ function App() {
               <AdminLogin userData={userData} setUserData={setUserData} />
             }
           />
-          <Route path="/test" element={<Test userData={userData} />} />
+          <Route path="/test" element={<Test userData={userData} setUserData={setUserData}/>} />
           <Route path="/finish" element={<TestResult />} />
           <Route
             path="*"

--- a/client/src/containers/Dashboard.jsx
+++ b/client/src/containers/Dashboard.jsx
@@ -1,5 +1,5 @@
 import "../styles/Dashboard.css";
-import { Link } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { FaPlus } from "react-icons/fa";
 import { useState, useEffect } from "react";
 import axiosAPICaller from "../services/api-service.mjs";
@@ -15,6 +15,12 @@ const Dashboard = () => {
       setData(response.data);
     });
   }, []);
+
+  // Redirect non-admin user to home page
+  // TODO: if user refreshes page, sessionstorage persists
+  if (!sessionStorage.getItem("adminRights")) {
+    return <Navigate to="/" />
+  }
 
   // we'll need to authenticate users below this route, maybe check
   // their email with db for admin privilege?

--- a/client/src/containers/Home.jsx
+++ b/client/src/containers/Home.jsx
@@ -1,6 +1,6 @@
 import "../styles/Home.css";
 import { useState, useRef } from "react";
-import { Link } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { MdErrorOutline } from "react-icons/md";
 import logo from "../assets/logo.png";
 
@@ -11,6 +11,11 @@ const Home = (props) => {
   const nameRef = useRef(null);
   const codeRef = useRef(null);
   const [error, setError] = useState("");
+
+  // Redirect admin user to dashboard
+  if (sessionStorage.getItem("adminRights") && userData.name) {
+    return <Navigate to="/dashboard" />
+  }
 
   sessionStorage.setItem("redirectAdmin", "false");
 
@@ -88,17 +93,17 @@ const Home = (props) => {
           // Introduction to the test
           <>
             <p>
-              Welcome <b>{userData.name}</b> to Visuo. You will be tested on
-              your <i>visuospatial</i> ability. There are [x] number of
-              questions, you will have [x] minutes to complete the test.
+              Logged in as: <b>{userData.name}</b> 
+              <br />
+              Test Code: <b>{sessionStorage.getItem("code")}</b>
               <br />
               <br />
-              To begin, click on the big <b>"Start!"</b> button below. <br />
+              To begin, click on the big <b>"Start"</b> button below. <br />
               <br />
               <b>Good Luck!</b>
             </p>
             <Link to="/test" className="home__input home__input--button">
-              Start!
+              Start
             </Link>
           </>
         )}

--- a/client/src/containers/Test.jsx
+++ b/client/src/containers/Test.jsx
@@ -8,7 +8,7 @@ import QuestionNavigation from "../components/QuestionNavigation";
 import axiosAPICaller from "../services/api-service.mjs";
 
 const Test = (props) => {
-  const { userData } = props;
+  const { userData, setUserData } = props;
   const timer = useRef(null); // Used for countdown timer
   const [questions, setQuestions] = useState([]);
   const [totalTime, setTotalTime] = useState(null);
@@ -24,6 +24,7 @@ const Test = (props) => {
   const [started, setStarted] = useState(false);
   const [testDetails, setTestDetails] = useState({});
   const testCode = sessionStorage.getItem("code");
+  const studentName = userData.name;
 
   // Disable enter key entirely, prevents next button from disappearing.
   window.addEventListener("keydown", function (e) {
@@ -40,6 +41,12 @@ const Test = (props) => {
         process.env.NODE_ENV === "production"
           ? process.env.REACT_APP_DOMAIN
           : `http://localhost:3000/`;
+    } else {
+      setUserData({
+        name: null,
+        email: null,
+        picture: null,
+      });
     }
 
     axiosAPICaller.get(`/test/code/${testCode}`).then(
@@ -114,30 +121,23 @@ const Test = (props) => {
 
   const finishTest = () => {
     if (!submitted) {
-      if (userData.name) {
-        // Create answer in DB if user logged in
-        let testData = {
-          testCode: testCode,
-          studentName: userData.name,
-          answers: userAnswers,
-          totalTimeTaken: timeTaken,
-        };
+    // Create studentanswer in DB
+    let testData = {
+      testCode: testCode,
+      studentName: studentName,
+      answers: userAnswers,
+      totalTimeTaken: timeTaken,
+    };
 
-        axiosAPICaller
-          .post("/answer/", testData)
-          .then(setSubmitted(true))
-          .then(
-            (window.location.href =
-              process.env.NODE_ENV === "production"
-                ? `${process.env.REACT_APP_DOMAIN}/finish`
-                : `http://localhost:3000/finish`)
-          );
-      } else {
-        window.location.href =
+    axiosAPICaller
+      .post("/answer/", testData)
+      .then(setSubmitted(true))
+      .then(
+        (window.location.href =
           process.env.NODE_ENV === "production"
             ? `${process.env.REACT_APP_DOMAIN}/finish`
-            : `http://localhost:3000/finish`;
-      }
+            : `http://localhost:3000/finish`)
+      );
     }
   };
 

--- a/client/src/services/auth-service.mjs
+++ b/client/src/services/auth-service.mjs
@@ -55,6 +55,7 @@ const adminLogin = async (name,gIdToken) => {
   )
   .then((res) => {
     sessionStorage.setItem("accessToken", res.data.accessToken);
+    sessionStorage.setItem("adminRights", true);
     return res.data;
   });
 }
@@ -72,6 +73,7 @@ const logout = async () => {
     .then((res) => {
       sessionStorage.removeItem("accessToken");
       sessionStorage.removeItem("code");
+      sessionStorage.removeItem("adminRights")
     });
 };
 


### PR DESCRIPTION
Redirect admins to dashboard if they go to the home page.
Redirect non-admins to the home page if they try to access the dashboard.
Prevent students from being able to restart the test by going back pages using the browser (reset userData when test starts).

Todo:
Check if refreshing on the admin dashboard should allow the user to keep using the dashboard.
